### PR TITLE
Conditionally enable/disable start/stop and load script / path walker buttons.

### DIFF
--- a/app/src/main/java/bot/Main.java
+++ b/app/src/main/java/bot/Main.java
@@ -451,6 +451,7 @@ public class Main {
         isRunning = true;
         startStopButton.setText("Stop");
       }
+      syncMainMenuButtonsEnabledStatusToBackingState();
     }
 
     if (config.getScreenRefresh()) {
@@ -706,6 +707,7 @@ public class Main {
     botFrame.setLayout(new BoxLayout(botFrame, BoxLayout.Y_AXIS));
 
     startStopButton = new JButton(isRunning ? "Stop" : "Start");
+    startStopButton.setEnabled(currentRunningScript != null);
 
     autoLoginCheckbox = new JCheckBox("Auto-Login");
     debugCheckbox = new JCheckBox("Debug Messages");
@@ -723,12 +725,18 @@ public class Main {
 
     startStopButton.addActionListener(
         e -> {
+          if (currentRunningScript == null) {
+            return;
+          }
+
           isRunning = !isRunning;
           if (isRunning) {
             startStopButton.setText("Stop");
           } else {
             startStopButton.setText("Start");
           }
+
+          syncMainMenuButtonsEnabledStatusToBackingState();
         });
 
     loadScriptButton.addActionListener(e -> showLoadScript());
@@ -743,6 +751,7 @@ public class Main {
           } else {
             JOptionPane.showMessageDialog(null, "Stop the current script first.");
           }
+          syncMainMenuButtonsEnabledStatusToBackingState();
         });
 
     openDebuggerButton.addActionListener(
@@ -1036,6 +1045,7 @@ public class Main {
               startStopButton.setText("Stop");
               scriptFrame.setVisible(false);
             }
+            syncMainMenuButtonsEnabledStatusToBackingState();
           }
         });
 
@@ -1265,6 +1275,12 @@ public class Main {
     }
   }
 
+  private static void syncMainMenuButtonsEnabledStatusToBackingState() {
+    loadScriptButton.setEnabled(!isRunning);
+    pathwalkerButton.setEnabled(!isRunning);
+    startStopButton.setEnabled(currentRunningScript != null);
+  }
+
   private static void setIconStyle(boolean newIcons) {
     // Create Cache directory
     File dir = new File("." + File.separator + "Cache");
@@ -1486,6 +1502,7 @@ public class Main {
     } else {
       startStopButton.setText("Start");
     }
+    syncMainMenuButtonsEnabledStatusToBackingState();
   }
 
   /**


### PR DESCRIPTION
Related to https://github.com/Open-RSC/IdleRSC/issues/1, I also encountered this issue.

Performing any set of actions which are not happy path results in the client being stuck with a warning that a script is already loaded. This happens because isRunning and currentRunningScript become out of sync.

The code to handle these buttons should be revisited at some point because there would ideally be one mechanism which sets each state to more reliably prevent these sorts of issues. I was not able to break the client with these changes in the interim.